### PR TITLE
Add some macros to reduce boilerplate.

### DIFF
--- a/examples/dummy/test.py
+++ b/examples/dummy/test.py
@@ -9,9 +9,7 @@ mod_code = """
 extern void cm_dummy(ARGS);
 
 int main(int argc, char **argv) {
-    Mif_Private_t* mif_private = allocate_mif_private();
-    init_connections(mif_private);
-    init_params(mif_private);
+    GJ_SETUP(mif_private);
 
     INIT = MIF_TRUE;
     cm_dummy(mif_private);
@@ -19,7 +17,7 @@ int main(int argc, char **argv) {
     INIT = MIF_FALSE;
     cm_dummy(mif_private);
 
-    free_mif_private(mif_private);
+    GJ_TEARDOWN(mif_private);
     return 0;
 }
 """

--- a/gomjabbar/data/macros.c
+++ b/gomjabbar/data/macros.c
@@ -1,0 +1,8 @@
+
+#define GJ_SETUP(name) \
+Mif_Private_t* name = allocate_mif_private();\
+init_connections(name);\
+init_params(name);
+
+#define GJ_TEARDOWN(name) \
+free_mif_private(name);

--- a/gomjabbar/generate.py
+++ b/gomjabbar/generate.py
@@ -127,3 +127,6 @@ def _render_templates(fp, connections, parameters, num_static_vars):
     template = TEMPLATE_ENV.get_template('params.c.jinja')
     context = {'parameters': parameters}
     fp.write(template.render(context))
+
+    macros_source = TEMPLATE_LOADER.get_source(TEMPLATE_ENV, 'macros.c')[0]
+    fp.write(macros_source)


### PR DESCRIPTION
Setting up the data structure to be passed as `ARGS` now just requires a `GJ_SETUP(whatever_name_you_like);` at the top of a test function. Teardown is handled by the `GJ_TEARDOWN` macro.