### PR TITLE
Simplify the signature of build_test

### DIFF
--- a/examples/dummy/test.py
+++ b/examples/dummy/test.py
@@ -6,11 +6,15 @@ from subprocess import check_output
 from gomjabbar.generate import build_test
 
 mod_code = """
+#include <stdio.h>
+
 int main(int argc, char **argv) {
     GJ_SETUP(mif_private);
 
     INIT = MIF_TRUE;
     cm_dummy(mif_private);
+
+    printf("%4.1f\\n", PARAM(d));
 
     INIT = MIF_FALSE;
     cm_dummy(mif_private);
@@ -27,11 +31,13 @@ def run(path):
 
 
 def main():
+    code_model_dir = op.dirname(__file__)
     parameters = {
         'd': 42.0,
     }
-    with build_test(op.dirname(__file__), 'test', mod_code, parameters) as pth:
-        run(pth)
+    with build_test(code_model_dir, mod_code, parameters) as pth:
+        output = run(pth)
+        assert output == '42.0'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's not important what the names of temporary files are.

Also, added description of the parameters to `build_test` in its docstring.